### PR TITLE
Fixed condition in Client (getHttpClient method)

### DIFF
--- a/src/Services/Client.php
+++ b/src/Services/Client.php
@@ -440,7 +440,7 @@ class Client
 	 */
 	private function getHttpClient()
 	{
-		if (!$this->httpClient instanceof Client) {
+		if (!$this->httpClient instanceof HttpClient) {
 			$config = $this->getConfig($this->getEnvironment());
 			/* @var GuzzleHttp\Client */
 			$this->httpClient = new HttpClient([


### PR DESCRIPTION
`getHttpClient` everytime creates new httpClient, because `$this->httpClient` can't be instance of `Client`. I think you wanted to check if `$this->httpClient` is instance of `HttpClient` instead of `Client`.