### PR TITLE
Error handlers and docs corrections

### DIFF
--- a/doc/ORDERS.md
+++ b/doc/ORDERS.md
@@ -232,7 +232,7 @@ When you want to set when the order was delivered to customer, use 5th parameter
 Pass this only with Order::STATUS_DELIVERED, you will recieve 400 Bad request otherwise.
 
 ```
-$responseStatus = $orders->put()->status($order->getOrderId(), Order::STATUS_DELIVERED, true, '', $dateTimeOfDelivery);
+$responseStatus = $orders->put()->status($order->getOrderId(), Order::STATUS_DELIVERED, true, '', new \DateTime('2017-08-29 10:09:25'));
 ```
 
 You will set the tracking number of the order with its order ID as the first and tracking number as the second parameter:  

--- a/doc/ORDERS.md
+++ b/doc/ORDERS.md
@@ -232,7 +232,7 @@ When you want to set when the order was delivered to customer, use 5th parameter
 Pass this only with Order::STATUS_DELIVERED, you will recieve 400 Bad request otherwise.
 
 ```
-$responseStatus = $order->put->status($order->getOrderId(), Order::STATUS_DELIVERED, true, '', $dateTimeOfDelivery);
+$responseStatus = $orders->put()->status($order->getOrderId(), Order::STATUS_DELIVERED, true, '', $dateTimeOfDelivery);
 ```
 
 You will set the tracking number of the order with its order ID as the first and tracking number as the second parameter:  

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -2,7 +2,7 @@
 
 namespace MPAPI\Entity;
 
-use MPAPI\Lib\Helpers\InputDataHelper;
+use MPAPI\Entity\AbstractEntity;
 
 /**
  * Order entity
@@ -204,6 +204,12 @@ class Order extends AbstractEntity
 	 */
 	const KEY_CUSTOMER_ID = 'customer_id';
 
+    /**
+     *
+     * @var string
+     */
+    const KEY_OPENED = 'open';
+
 	/**
 	 *
 	 * @var string
@@ -262,81 +268,6 @@ class Order extends AbstractEntity
 	 * @var string
 	 */
 	const KEY_MDP = 'mdp';
-
-	/**
-	 * @var string
-	 */
-	const KEY_BRANCHES = 'branches';
-
-	/**
-	 * @var string
-	 */
-	const KEY_BRANCH_ID = 'branch_id';
-
-	/**
-	 * @var string
-	 */
-	const KEY_SECONDARY_BRANCH_ID = 'secondary_branch_id';
-
-	/**
-	 * @var string
-	 */
-	const KEY_OVERRIDDEN = 'overridden';
-
-	/**
-	 * @var string
-	 */
-	const KEY_LAST_CHANGE = 'last_change';
-
-	/**
-	 * @var string
-	 */
-	const KEY_FIRST_DELIVERY_ATTEMPT = 'first_delivery_attempt';
-
-	/**
-	 * @var string
-	 */
-	const KEY_READY_TO_RETURN = 'ready_to_return';
-
-	/**
-	 * @var string
-	 */
-	const KEY_SHIPPED = 'shipped';
-
-	/**
-	 * @var string
-	 */
-	const KEY_OPEN = 'open';
-
-	/**
-	 * @var string
-	 */
-	const KEY_BLOCKED = 'blocked';
-
-	/**
-	 * @var string
-	 */
-	const KEY_LOST = 'lost';
-
-	/**
-	 * @var string
-	 */
-	const KEY_RETURNED = 'returned';
-
-	/**
-	 * @var string
-	 */
-	const KEY_CANCELLED = 'cancelled';
-
-	/**
-	 * @var string
-	 */
-	const KEY_DELIVERED = 'delivered';
-
-	/**
-	 * @var string
-	 */
-	const KEY_SHIPPING = 'shipping';
 
 	/**
 	 *
@@ -431,23 +362,6 @@ class Order extends AbstractEntity
 			'status' => $this->getStatus(),
 			'items' => $this->getItems(),
 			'mdp' => $this->getMdp(),
-			'branch_id' => $this->getBranchId(),
-			'branches' => [
-				'branch_id' => $this->getMainBranchId(),
-				'secondary_branch_id' => $this->getSecondaryBranchId(),
-				'overridden' => $this->isBranchOverridden(),
-				'last_change' => $this->getBranchLastChange(),
-			],
-			'first_delivery_attempt' => $this->getFirstDeliveryAttempt(),
-			'ready_to_return' => $this->isReadyToReturn(),
-			'shipped' => $this->getShippedStatus(),
-			'open' => $this->getOpenStatus(),
-			'blocked' => $this->getBlockedStatus(),
-			'lost' => $this->getLostStatus(),
-			'returned' => $this->getReturnedStatus(),
-			'cancelled' => $this->getCancelledStatus(),
-			'delivered' => $this->getDeliveredStatus(),
-			'shipping' => $this->getShippingStatus(),
 		];
 	}
 
@@ -470,7 +384,7 @@ class Order extends AbstractEntity
 	/**
 	 * Get order items
 	 *
-	 * @return array Order items
+	 * @return OrderItem[]
 	 */
 	public function getItems()
 	{
@@ -480,17 +394,21 @@ class Order extends AbstractEntity
 	/**
 	 * Get partner id
 	 *
-	 * @return int
+	 * return integer
 	 */
 	public function getPartnerId()
 	{
-		return InputDataHelper::getInt($this->data, [self::KEY_PARTNER_ID]);
+		$retval = 0;
+		if (isset($this->data[self::KEY_PARTNER_ID])) {
+			$retval = (int)$this->data[self::KEY_PARTNER_ID];
+		}
+		return $retval;
 	}
 
 	/**
 	 * Set partner id
 	 *
-	 * @param int $partnerId
+	 * @param integer $partnerId
 	 * @return Order
 	 */
 	public function setPartnerId($partnerId)
@@ -500,7 +418,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return int
+	 * return integer
 	 */
 	public function getPurchaseId()
 	{
@@ -508,7 +426,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getCurrencyId()
 	{
@@ -516,7 +434,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return int
+	 * return integer
 	 */
 	public function getDeliveryPrice()
 	{
@@ -524,7 +442,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getDeliveryMethod()
 	{
@@ -532,7 +450,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return int
+	 * return integer
 	 */
 	public function getDeliveryMethodId()
 	{
@@ -540,7 +458,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return int
+	 * return integer
 	 */
 	public function getDeliveryPosition()
 	{
@@ -548,7 +466,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getDeliveryDate()
 	{
@@ -560,11 +478,15 @@ class Order extends AbstractEntity
 	 */
 	public function getDeliveredAt()
 	{
-		return InputDataHelper::getString($this->data, [self::KEY_DELIVERED_AT]);
+		$retval = '';
+		if (isset($this->data[self::KEY_DELIVERED_AT])) {
+			$retval = $this->data[self::KEY_DELIVERED_AT];
+		}
+		return $retval;
 	}
 
 	/**
-	 * @return float
+	 * return double
 	 */
 	public function getCod()
 	{
@@ -572,7 +494,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getName()
 	{
@@ -580,15 +502,19 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getCompany()
 	{
-		return InputDataHelper::getString($this->data, [self::KEY_ADDRESS, self::KEY_COMPANY]);
+		$retval = '';
+		if (!empty($this->data[self::KEY_ADDRESS][self::KEY_COMPANY])) {
+			$retval = $this->data[self::KEY_ADDRESS][self::KEY_COMPANY];
+		}
+		return $retval;
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getPhone()
 	{
@@ -596,7 +522,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getEmail()
 	{
@@ -604,7 +530,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getStreet()
 	{
@@ -612,7 +538,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getCity()
 	{
@@ -620,7 +546,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getZip()
 	{
@@ -628,7 +554,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getCountry()
 	{
@@ -636,7 +562,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getConfirmed()
 	{
@@ -644,7 +570,7 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getStatus()
 	{
@@ -652,27 +578,39 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return double
+	 * return double
 	 */
 	public function getCodPrice()
 	{
-		return InputDataHelper::getFloat($this->data, [self::KEY_COD_PRICE]);
+		$retval = 0;
+		if (!empty($this->data[self::KEY_COD_PRICE])) {
+			$retval = $this->data[self::KEY_COD_PRICE];
+		}
+		return $retval;
 	}
 
 	/**
-	 * @return int
+	 * return integer
 	 */
 	public function getTransportId()
 	{
-		return InputDataHelper::getInt($this->data, [self::KEY_TRANSPORT_ID]);
+		$retval = [];
+		if (isset($this->data[self::KEY_TRANSPORT_ID])) {
+			$retval = $this->data[self::KEY_TRANSPORT_ID];
+		}
+		return $retval;
 	}
 
 	/**
-	 * @return string
+	 * return string
 	 */
 	public function getTrackingNumber()
 	{
-		return InputDataHelper::getString($this->data, [self::KEY_TRACKING_NO]);
+		$retval = '';
+		if (isset($this->data[self::KEY_TRACKING_NO])) {
+			$retval = $this->data[self::KEY_TRACKING_NO];
+		}
+		return $retval;
 	}
 
 	/**
@@ -680,11 +618,15 @@ class Order extends AbstractEntity
 	 */
 	public function getTrackingUrl()
 	{
-		return InputDataHelper::getString($this->data, [self::KEY_TRACKING_URL]);
+		$retval = '';
+		if (isset($this->data[self::KEY_TRACKING_URL])) {
+			$retval = $this->data[self::KEY_TRACKING_URL];
+		}
+		return $retval;
 	}
 
 	/**
-	 * @return int
+	 * return integer
 	 */
 	public function getExternalOrderId()
 	{
@@ -692,35 +634,51 @@ class Order extends AbstractEntity
 	}
 
 	/**
-	 * @return int
+	 * return integer
 	 */
 	public function getDiscount()
 	{
-		return InputDataHelper::getInt($this->data, [self::KEY_DISCOUNT]);
+		$retval = 0;
+		if (isset($this->data[self::KEY_DISCOUNT])) {
+			$retval = $this->data[self::KEY_DISCOUNT];
+		}
+		return $retval;
 	}
 
 	/**
-	 * @return int|null
+	 * return integer
 	 */
 	public function getPaymentType()
 	{
-		return InputDataHelper::getNullableInt($this->data, [self::KEY_PAYMENT_TYPE]);
+		$retval = null;
+		if (isset($this->data[self::KEY_PAYMENT_TYPE])) {
+			$retval = $this->data[self::KEY_PAYMENT_TYPE];
+		}
+		return $retval;
 	}
 
 	/**
-	 * @return string|null
+	 * return date
 	 */
 	public function getCreated()
 	{
-		return InputDataHelper::getNullableString($this->data, [self::KEY_CREATED]);
+		$retval = null;
+		if (isset($this->data[self::KEY_CREATED])) {
+			$retval = $this->data[self::KEY_CREATED];
+		}
+		return $retval;
 	}
 
 	/**
-	 * @return int|null
+	 * return integer
 	 */
 	public function getCustomerId()
 	{
-		return InputDataHelper::getNullableInt($this->data, [self::KEY_ADDRESS, self::KEY_CUSTOMER_ID]);
+		$retval = null;
+		if (isset($this->data[self::KEY_ADDRESS][self::KEY_CUSTOMER_ID])) {
+			$retval = $this->data[self::KEY_ADDRESS][self::KEY_CUSTOMER_ID];
+		}
+		return $retval;
 	}
 
 	/**
@@ -728,8 +686,20 @@ class Order extends AbstractEntity
 	 */
 	public function getMdp()
 	{
-		return (bool) $this->data[self::KEY_MDP];
+		return (bool)$this->data[self::KEY_MDP];
 	}
+
+    /**
+     * return date
+     */
+    public function getOpened()
+    {
+        $retval = null;
+        if (isset($this->data[self::KEY_OPENED])) {
+            $retval = $this->data[self::KEY_OPENED];
+        }
+        return $retval;
+    }
 
 	/**
 	 * Set order status
@@ -754,125 +724,4 @@ class Order extends AbstractEntity
 		$this->data[self::KEY_CONFIRMED] = $confirmed;
 		return $this;
 	}
-
-	/**
-	 * @return int|null
-	 */
-	public function getBranchId()
-	{
-		return InputDataHelper::getNullableInt($this->data, [self::KEY_BRANCH_ID]);
-	}
-
-	/**
-	 * @return int|null
-	 */
-	public function getMainBranchId()
-	{
-		return InputDataHelper::getNullableInt($this->data, [self::KEY_BRANCHES, self::KEY_BRANCH_ID]);
-	}
-
-	/**
-	 * @return int|null
-	 */
-	public function getSecondaryBranchId()
-	{
-		return InputDataHelper::getNullableInt($this->data, [self::KEY_BRANCHES, self::KEY_SECONDARY_BRANCH_ID]);
-	}
-
-	/**
-	 * @return bool
-	 */
-	public function isBranchOverridden()
-	{
-		return (bool) $this->data[self::KEY_BRANCHES][self::KEY_OVERRIDDEN];
-	}
-
-	/**
-	 * @return string|null
-	 */
-	public function getBranchLastChange()
-	{
-		return InputDataHelper::getNullableString($this->data, [self::KEY_BRANCHES, self::KEY_LAST_CHANGE]);
-	}
-
-	/**
-	 * @return string|null
-	 */
-	public function getFirstDeliveryAttempt()
-	{
-		return InputDataHelper::getNullableString($this->data, [self::KEY_FIRST_DELIVERY_ATTEMPT]);
-	}
-
-	/**
-	 * @return bool
-	 */
-	public function isReadyToReturn()
-	{
-		return (bool) $this->data[self::KEY_READY_TO_RETURN];
-	}
-
-	/**
-	 * @return string|null
-	 */
-	public function getShippedStatus()
-	{
-		return InputDataHelper::getNullableString($this->data, [self::KEY_SHIPPED]);
-	}
-
-	/**
-	 * @return string|null
-	 */
-	public function getOpenStatus()
-	{
-		return InputDataHelper::getNullableString($this->data, [self::KEY_OPEN]);
-	}
-
-	/**
-	 * @return string|null
-	 */
-	public function getBlockedStatus()
-	{
-		return InputDataHelper::getNullableString($this->data, [self::KEY_BLOCKED]);
-	}
-
-	/**
-	 * @return string|null
-	 */
-	public function getLostStatus()
-	{
-		return InputDataHelper::getNullableString($this->data, [self::KEY_LOST]);
-	}
-
-	/**
-	 * @return string|null
-	 */
-	public function getReturnedStatus()
-	{
-		return InputDataHelper::getNullableString($this->data, [self::KEY_RETURNED]);
-	}
-
-	/**
-	 * @return string|null
-	 */
-	public function getCancelledStatus()
-	{
-		return InputDataHelper::getNullableString($this->data, [self::KEY_CANCELLED]);
-	}
-
-	/**
-	 * @return string|null
-	 */
-	public function getDeliveredStatus()
-	{
-		return InputDataHelper::getNullableString($this->data, [self::KEY_DELIVERED]);
-	}
-
-	/**
-	 * @return string|null
-	 */
-	public function getShippingStatus()
-	{
-		return InputDataHelper::getNullableString($this->data, [self::KEY_SHIPPING]);
-	}
-
 }

--- a/src/Lib/Handlers/ExceptionHandler.php
+++ b/src/Lib/Handlers/ExceptionHandler.php
@@ -29,7 +29,7 @@ class ExceptionHandler
 	 * @param \Exception $exception
 	 * @return ExceptionHandler
 	 */
-	public function __invoke(\Exception $exception)
+	public function __invoke($exception)
 	{
 		$this->logger->error($exception->getMessage());
 		print($exception->getMessage() . PHP_EOL);


### PR DESCRIPTION
https://github.com/mallgroup/mpapi-client-php/commit/fe8d7634ef8b8b5c3474e9d1ba133422d5f213c4 
---
If DateTime interface is not implemented within changing order status to delivered, ErrorHandler gets TypeError instead of Exception, so it is better to not define the type of incoming $exception type. In this state developer gets an Uncaught fatal error

https://github.com/mallgroup/mpapi-client-php/commit/566faf2aee3403d446ed6d46793440e580256f0f
---
There should be $orders instead of $order and put() instead of put

https://github.com/mallgroup/mpapi-client-php/commit/fe8d7634ef8b8b5c3474e9d1ba133422d5f213c4
---
It is not clear, that DateTime interface is necessary to use, so it is better to show developer in this example (developers could also expect string).